### PR TITLE
Fix for issue #295

### DIFF
--- a/src/aws_bedrock_llms.ts
+++ b/src/aws_bedrock_llms.ts
@@ -984,10 +984,17 @@ function fromAwsBedrockChoice(
   choice: ConverseCommandOutput,
   jsonMode = false,
 ): ModelResponseData {
-  const toolRequestParts =
-    choice.output?.message?.content && choice.output.message.content[0].toolUse
-      ? fromAwsBedrockToolCall(choice.output.message.content[0].toolUse)
-      : [];
+
+  // Find all tool use blocks in the content array
+  const toolRequestParts: any[] = [];
+  if (choice.output?.message?.content) {
+    for (const contentBlock of choice.output.message.content) {
+      if (contentBlock.toolUse) {
+        toolRequestParts.push(...fromAwsBedrockToolCall(contentBlock.toolUse));
+      }
+    }
+  }
+  
   return {
     finishReason:
       "stopReason" in choice ? finishReasonMap[choice.stopReason!] : "other",


### PR DESCRIPTION
**This pull request is related to:**

- [x] A bug
- [ ] A new feature
- [ ] Documentation
- [ ] Other (please specify)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/xavidop/genkitx-aws-bedrock/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/xavidop/genkitx-aws-bedrock/blob/main/CODE_OF_CONDUCT.md);
- [ ] I have added new tests (for bug fixes/features);
- [ ] I have added/updated the documentation (for bug fixes / features).

**Description:**
I'm providing a fix for issue #295. 
The Bedrock Claude 3.7 Sonnet answer contains an array of "content" in the output message and the fromAwsBedrockChoice() function was only considering the first element in the content array. 
In the issue, the submitted example shows that the tool usage request is actually in the second element of the array, hence the implementation of the function was missing that and tools were not being used. 

I tested the current fix and tools are now successfully used. 

Hope that helps :) 

**Related issues:**
Issue #295 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool invocation handling to process all tool requests within a single response, instead of only the first. This enables proper support for multiple tool calls in complex interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->