### PR TITLE
feat: adding abortSignal to client send commands

### DIFF
--- a/src/aws_bedrock_llms.ts
+++ b/src/aws_bedrock_llms.ts
@@ -1257,6 +1257,7 @@ export function awsBedrockModel(
       {
         streamingRequested,
         sendChunk,
+        abortSignal
       }: {
         streamingRequested: boolean;
         sendChunk: (chunk: GenerateResponseChunkData) => void;
@@ -1267,7 +1268,9 @@ export function awsBedrockModel(
       const body = toAwsBedrockRequestBody(name, request, inferenceRegion);
       if (streamingRequested) {
         const command = new ConverseStreamCommand(body);
-        response = await client.send(command);
+        response = await client.send(command, {
+            abortSignal,
+        });
 
         // Accumulate text content from streaming response
         let accumulatedText = "";
@@ -1389,7 +1392,9 @@ export function awsBedrockModel(
         };
       } else {
         const command = new ConverseCommand(body);
-        const converseResponse = await client.send(command);
+        const converseResponse = await client.send(command, {
+            abortSignal
+        });
 
         return {
           message: fromAwsBedrockChoice(


### PR DESCRIPTION
_Before you submit a pull request, please make sure you have read and understood the [contribution guidelines](https://github.com/genkit-ai/aws-bedrock-js-plugin/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/genkit-ai/aws-bedrock-js-plugin/blob/main/CODE_OF_CONDUCT.md)._

**This pull request is related to:**

- [ ] A bug
- [x] A new feature
- [ ] Documentation
- [ ] Other (please specify)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/genkit-ai/aws-bedrock-js-plugin/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/genkit-ai/aws-bedrock-js-plugin/blob/main/CODE_OF_CONDUCT.md);
- [] I have added new tests (for bug fixes/features);
- [] I have added/updated the documentation (for bug fixes / features).

**Description:**
While working on implementing a AbortSignal in a genkit flow, I noticed that the genkitx-aws-bedrock package looked like it was almost wired up, but never connected to the Bedrock client executions. This adds the `abortSignal` signal to the `client.send` commands.

I didn't see a way to test this or to add it to any documentation, unfortunately.


