### PR TITLE
feat: handling msg.data from the model instead of msg.text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,41 @@ const result = ai.generate({
 console.log(result.then((res) => res.text));
 ```
 
+### Structured Output
+
+In order to use [Genkit structured output](https://genkit.dev/docs/js/models/#structured-output) with the Bedrock APIs, the schema sent to Bedrock needs to have `additionalProperties` set to false. If you have your schemas defined as `zod` schemas you can use `zodToJsonSchema` along with `schema.strict()` to get it in the correct format
+
+```typescript
+// ...configure Genkit (as shown above)...
+
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+const outputSchema = z.object({
+    joke: z.string()
+});
+const structuredOutputSchema = zodToJsonSchema(
+    outputSchema.strict()
+);
+
+// Results in an error:
+// output_config.format.schema: For 'object' type, 'additionalProperties: true' is not supported. Please set 'additionalProperties' to false
+const response = await ai.generate({
+  prompt: 'Tell me a joke.',
+  output: {
+    schema: outputSchema
+  }
+});
+
+// Works correctly!
+const response = await ai.generate({
+  prompt: 'Tell me a joke.',
+  output: {
+    format: 'json',
+    jsonSchema: structuredOutputSchema
+  }
+});
+```
+
 For more detailed examples and the explanation of other functionalities, refer to the [official Genkit documentation](https://genkit.dev/).
 
 ## Using Custom Models

--- a/examples/generate/src/index.ts
+++ b/examples/generate/src/index.ts
@@ -21,9 +21,10 @@ import { genkit, z } from 'genkit';
 import { 
   anthropicClaude35SonnetV2, 
   awsBedrock,
-  amazonTitanEmbedTextV2 
+  amazonTitanEmbedTextV2,
+  anthropicClaudeSonnet45V1
 } from 'genkitx-bedrock';
-
+import { zodToJsonSchema } from 'zod-to-json-schema';
 
 dotenv.config();
 
@@ -31,9 +32,7 @@ const ai = genkit({
   plugins: [
     awsBedrock({
       // Register custom models here
-      customModels: [
-        'openai.gpt-oss-20b-1:0', 
-        'us.anthropic.claude-sonnet-4-5-20250929-v1:0'],
+      customModels: ['openai.gpt-oss-20b-1:0'],
     }),
   ],
   model: anthropicClaude35SonnetV2('us'),
@@ -133,6 +132,13 @@ export const embedderFlow = ai.defineFlow(
  * }
  * ```
  */
+// Required to convert the Zod schema to a JSON schema for the Bedrock model
+const outputSchema = z.object({
+    name: z.string().describe('The name of the person'),
+    age: z.number().describe('The age of the person'),
+});
+const structuredOutputSchema = zodToJsonSchema(outputSchema.strict());
+
 export const structuredOutputFlow = ai.defineFlow(
   {
     name: 'structuredOutputFlow',
@@ -142,20 +148,39 @@ export const structuredOutputFlow = ai.defineFlow(
   async (input) => {
     const result = await ai.generate({
       prompt: input,
-      model: 'aws-bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+      model: anthropicClaudeSonnet45V1('us'),
       output: {
         format: 'json',
-        schema: z.object({
-          name: z.string(),
-          age: z.number(),
-        })
+        jsonSchema: structuredOutputSchema
       }
     });
 
-    console.log('Result', result);
-    return result.text;
+    return result.text || JSON.stringify(result.output);
   }
 );
+
+export const structuredOutputFlowWithPreviousMessages = ai.defineFlow(
+    {
+      name: 'structuredOutputFlowWithPreviousMessages',
+      inputSchema: z.string(),
+      outputSchema: z.string(),
+    },
+    async (input) => {
+      const result = await ai.generate({
+        prompt: input,
+        model: anthropicClaudeSonnet45V1('us'),
+        messages: [
+            { role: 'user', content: [{ text: 'What is your name and age?' }]},
+            { role: 'model', content: [{ data: { name: 'John', age: 30 }}]}
+        ],
+        output: {
+          format: 'json',
+          jsonSchema: structuredOutputSchema
+        }
+      });
+      return result.text || JSON.stringify(result.output);
+    }
+  );
 
 /**
  * Document analysis flow - demonstrates how to send documents (PDF, CSV, etc.)
@@ -264,5 +289,5 @@ export const csvAnalysisFlow = ai.defineFlow(
 );
 
 startFlowServer({
-  flows: [jokeFlow, customModelFlow, streamingFlow, embedderFlow, documentAnalysisFlow, csvAnalysisFlow, structuredOutputFlow],
+  flows: [jokeFlow, customModelFlow, streamingFlow, embedderFlow, documentAnalysisFlow, csvAnalysisFlow, structuredOutputFlow, structuredOutputFlowWithPreviousMessages],
 });

--- a/src/aws_bedrock_llms.ts
+++ b/src/aws_bedrock_llms.ts
@@ -1425,7 +1425,7 @@ export function toAwsBedrockMessages(
             role: role,
             content: [
               {
-                text: msg.data && !msg.text ? JSON.stringify(msg.data) : msg.text,
+                text: (msg.data !== undefined && !msg.text) ? JSON.stringify(msg.data) : msg.text,
               },
             ],
           });

--- a/src/aws_bedrock_llms.ts
+++ b/src/aws_bedrock_llms.ts
@@ -1425,7 +1425,7 @@ export function toAwsBedrockMessages(
             role: role,
             content: [
               {
-                text: msg.text,
+                text: msg.data && !msg.text ? JSON.stringify(msg.data) : msg.text,
               },
             ],
           });


### PR DESCRIPTION
Also, added documentation to include guidance on Genkit and Bedrock wireup that's needed to get Structured Output working correctly.

**This pull request is related to:**

- [ ] A bug
- [x] A new feature
- [X] Documentation
- [ ] Other (please specify)

**I have checked the following:**

- [x] I have read and understood the [contribution guidelines](https://github.com/genkit-ai/aws-bedrock-js-plugin/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/genkit-ai/aws-bedrock-js-plugin/blob/main/CODE_OF_CONDUCT.md);
- [x] I have added new tests (for bug fixes/features);
- [x] I have added/updated the documentation (for bug fixes / features).

**Description:**
When using Structured Output with Genkit and Bedrock in a multi-turn solution, the previous messages in the history contain a `content.data` property instead of a `content.text` property. The [AWS Bedrock ContentBlock](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlock.html) only supports TextMember and not Structured Output. This adds support to look for a `msg.data` property and `JSON.stringify` the property if it is set and if the `msg.text` property is not set, and then supplies the correct value to the `TextMember` content for the Model.

**Related issues:**
https://github.com/genkit-ai/aws-bedrock-js-plugin/issues/562
